### PR TITLE
chore!:  return an interface friendly version of GitRemote

### DIFF
--- a/get_remote.go
+++ b/get_remote.go
@@ -4,8 +4,8 @@ import "os"
 
 // GitRemote represents, well... a git remote
 type GitRemote struct {
-	Host    string
-	Project string
+	host    string
+	project string
 }
 
 // GetGitRemote returns a GitRemote instance based on the environment variables found during runtime
@@ -15,19 +15,29 @@ func GetGitRemote() GitRemote {
 	if isGitHub {
 		return GitRemote{
 			// Assuming no self-hosted GitHub, not even sure if actions works there tbh
-			Host:    "github.com",
-			Project: project,
+			host:    "github.com",
+			project: project,
 		}
 	}
 
 	// Otherwise it's GitLab
 	return GitRemote{
-		Host:    os.Getenv("CI_SERVER_HOST"),
-		Project: os.Getenv("CI_PROJECT_PATH"),
+		host:    os.Getenv("CI_SERVER_HOST"),
+		project: os.Getenv("CI_PROJECT_PATH"),
 	}
 }
 
 // GetRemoteURL builds an URL pointing to the specific project on the remote provider
 func (remote GitRemote) GetRemoteURL() string {
-	return "https://" + remote.Host + "/" + remote.Project
+	return "https://" + remote.host + "/" + remote.project
+}
+
+// Host returns the URL of the git host
+func (remote GitRemote) Host() string {
+	return remote.host
+}
+
+// Project returns the name of the project
+func (remote GitRemote) Project() string {
+	return remote.project
 }

--- a/get_remote_test.go
+++ b/get_remote_test.go
@@ -13,8 +13,8 @@ func TestGetGitRemote(t *testing.T) {
 	os.Setenv("GITHUB_REPOSITORY", "outillage/integrations")
 	gitRemote = GetGitRemote()
 
-	assert.Equal(t, "github.com", gitRemote.Host)
-	assert.Equal(t, "outillage/integrations", gitRemote.Project)
+	assert.Equal(t, "github.com", gitRemote.Host())
+	assert.Equal(t, "outillage/integrations", gitRemote.Project())
 
 	os.Clearenv()
 
@@ -22,6 +22,6 @@ func TestGetGitRemote(t *testing.T) {
 	os.Setenv("CI_PROJECT_PATH", "outillage/integrations")
 	gitRemote = GetGitRemote()
 
-	assert.Equal(t, "gitlab.com", gitRemote.Host)
-	assert.Equal(t, "outillage/integrations", gitRemote.Project)
+	assert.Equal(t, "gitlab.com", gitRemote.Host())
+	assert.Equal(t, "outillage/integrations", gitRemote.Project())
 }


### PR DESCRIPTION
BREAKING CHANGE: Host and Project are no longer directly accessible. This is to make this library friendlier to use with interfaces.